### PR TITLE
docs: use python3/apt commands and fix KAT default to 100

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ make ref/librmrs.so
 The only development dependency is pytest:
 
 ```bash
-pip install pytest
+apt install -y python3-pytest
 ```
 
 ---
@@ -61,13 +61,15 @@ pip install pytest
 ### Test suite
 
 ```bash
-make test                  # all tests (unit + KAT)
-pytest tests/ -v           # same, with verbose output
-pytest -m slow             # end-to-end and structural tests only
-KAT_N=3 pytest tests/      # run only the first 3 KAT vectors
+make test                          # unit + integration + all 100 KAT vectors
+pytest tests/ -m "not slow"        # quick check (skips full KEM cycles)
+pytest tests/ -m slow              # end-to-end and structural tests only
+KAT_N=3 pytest tests/test_kat.py   # first 3 KAT vectors, to iterate fast
 ```
 
-KAT tests are skipped automatically when `kat/PQCkemKAT_2321.rsp` is absent.
+`make test` validates all 100 KAT vectors byte for byte by default; lower
+`KAT_N` to run fewer. KAT tests are skipped automatically when
+`kat/PQCkemKAT_2321.rsp` is absent.
 
 ### Benchmarks
 

--- a/bench_kem.py
+++ b/bench_kem.py
@@ -2,8 +2,8 @@
 Benchmark for the three HQC-1 KEM operations: KeyGen, Encaps, Decaps.
 
 Usage:
-    python bench_kem.py             # quick benchmark  (10 iterations)
-    python bench_kem.py --full      # statistical benchmark (50 iterations)
+    python3 bench_kem.py             # quick benchmark  (10 iterations)
+    python3 bench_kem.py --full      # statistical benchmark (50 iterations)
 
 Times are reported in milliseconds (median, min, max). The last column
 converts the measured time to kcycles assuming the processor clock frequency

--- a/bench_poly_mul.py
+++ b/bench_poly_mul.py
@@ -2,8 +2,8 @@
 Benchmark and correctness check for the two polynomial multiplication algorithms.
 
 Usage:
-    python bench_poly_mul.py          # quick benchmark (1 sample)
-    python bench_poly_mul.py --full   # statistical benchmark (5 rounds x 3 reps)
+    python3 bench_poly_mul.py          # quick benchmark (1 sample)
+    python3 bench_poly_mul.py --full   # statistical benchmark (5 rounds x 3 reps)
 
 Algorithms compared:
   naive      poly_mul()           O(n^2)    -- readable, slow

--- a/tests/test_kat.py
+++ b/tests/test_kat.py
@@ -17,8 +17,8 @@ the same order as the reference:
   16 bytes -> m         (for encaps)
   16 bytes -> salt      (for encaps)
 
-KAT_N caps how many of the vectors are checked (default 10); raise it for a more
-exhaustive run, e.g. `KAT_N=100 pytest tests/test_kat.py`.
+KAT_N caps how many of the vectors are checked (default 100, the full set);
+lower it to iterate faster during development, e.g. `KAT_N=3 pytest tests/test_kat.py`.
 """
 
 import os


### PR DESCRIPTION
python3 in usage examples, install pytest via apt (python3-pytest), and document that make test validates all 100 KAT vectors.